### PR TITLE
factory helper type hints

### DIFF
--- a/src/tests/factories.py
+++ b/src/tests/factories.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from factory import Factory
+from factory import Factory, Sequence
 import datetime
 from awardsreport.models import ProcurementTransactions, AssistanceTransactions
 from faker import Faker
@@ -7,7 +7,7 @@ from faker import Faker
 fake = Faker()
 
 
-def generate_contract_award_unique_key():
+def generate_contract_award_unique_key() -> str:
     """Generate realistic contract award unique key values.
 
     See USAspending data dictionary PrimeAwardUniqueKey
@@ -24,7 +24,7 @@ def generate_contract_award_unique_key():
     return "_".join((piid, agency_id, parent_piid, idv_agency_id))
 
 
-def generate_asisstance_award_unique_key():
+def generate_asisstance_award_unique_key() -> str:
     """Generate realistic assistance award unique key values.
 
     See USAspending data dictionary PrimeAwardUniqueKey
@@ -74,6 +74,7 @@ class AssistanceTransactionsFactory(BaseTransactionsFactory):
         model = AssistanceTransactions
 
     assistance_award_unique_key = generate_asisstance_award_unique_key()
+    assistance_transaction_unique_key = Sequence(lambda n: n)
     assistance_type_code = fake.bothify("##")
     cfda_number = fake.bothify("##.###")
     cfda_title = fake.pystr(5, 10)
@@ -87,3 +88,4 @@ class ProcurementTransactionsFactory(BaseTransactionsFactory):
         model = ProcurementTransactions
 
     contract_award_unique_key = generate_contract_award_unique_key()
+    contract_transaction_unique_key = Sequence(lambda n: n)

--- a/src/tests/test_topline.py
+++ b/src/tests/test_topline.py
@@ -1,27 +1,32 @@
 import pytest
 from awardsreport.logic import topline
-from awardsreport.database import Session
+from sqlalchemy.orm import Session
 
 from tests.factories import AssistanceTransactionsFactory
 
 
-def test_get_award_type_month_total(db_session):
-    db_session.add(
-        AssistanceTransactionsFactory(
-            federal_action_obligation=100,
-            action_date="2023-05-01",
-            assistance_transaction_unique_key=1,
-        )
-    )
-    db_session.add(
-        AssistanceTransactionsFactory(
-            federal_action_obligation=100,
-            action_date="2023-05-01",
-            assistance_transaction_unique_key=2,
-        )
+def test_get_award_type_month_total(db_session: Session):
+    db_session.add_all(
+        [
+            AssistanceTransactionsFactory(
+                federal_action_obligation=1, action_date="2023-05-01"
+            ),
+            AssistanceTransactionsFactory(
+                federal_action_obligation=1, action_date="2023-05-31"
+            ),
+            AssistanceTransactionsFactory(
+                federal_action_obligation=-1, action_date="2023-05-01"
+            ),
+            AssistanceTransactionsFactory(
+                federal_action_obligation=1, action_date="2023-06-01"
+            ),
+            AssistanceTransactionsFactory(
+                federal_action_obligation=1, action_date="2022-05-01"
+            ),
+        ]
     )
     db_session.commit()
 
     result = topline.get_award_type_month_total(db_session, "assistance", 2023, 5)
-    expected_result = 200
+    expected_result = 1
     assert result == expected_result


### PR DESCRIPTION
src/tests/factories.py
- use Factory.Sequence to generate test data primary keys
- add type hints to award unique key helper functions

src/tests/test_topline.py
- add multiple records at once with add_all using Sequence in factories to generate unique primary keys.
- add test data for negative obligations and tx in other years and months.