### PR TITLE
Test get award type month total

### DIFF
--- a/src/awardsreport/logic/topline.py
+++ b/src/awardsreport/logic/topline.py
@@ -38,13 +38,14 @@ def get_award_type_month_total(
     }
     sum_col = type_cols[award_type]
     sum_tbl = sum_col.parent.class_
-
     stmt = select(func.sum(sum_col)).filter(
         extract("year", sum_tbl.action_date) == year,
         extract("month", sum_tbl.action_date) == month,
     )
+    if award_type == "assistance":
+        stmt = stmt.filter(sum_tbl.assistance_type_code.not_in(("07", "08")))
     if award_type == "loan":
-        stmt = stmt.where(sum_tbl.assistance_type_code.in_(("07", "08")))
+        stmt = stmt.filter(sum_tbl.assistance_type_code.in_(("07", "08")))
     results = session.scalar(stmt)
     return results
 

--- a/src/awardsreport/logic/topline.py
+++ b/src/awardsreport/logic/topline.py
@@ -73,27 +73,3 @@ def get_month_totals_2cat(year: int = YEAR, month: int = MONTH):
         "total": month_totals["assistance"] + month_totals["procurement"],
         "award_type_totals": month_totals,
     }
-
-
-def get_agency_obligations(record_limit: int = 3):
-    session = Session()
-    stmt = (
-        select(
-            ProcurementTransactions.awarding_agency_name,
-            func.sum(ProcurementTransactions.federal_action_obligation).label(
-                "sum_obl"
-            ),
-        )
-        .group_by(ProcurementTransactions.awarding_agency_name)
-        .order_by(desc("sum_obl"))
-        .limit(record_limit)
-    )
-    results = session.execute(stmt).all()
-    ag_ob = [
-        {
-            "awarding_agency_name": result.awarding_agency_name,
-            "sum_obl": result.sum_obl,
-        }
-        for result in results
-    ]
-    return ag_ob

--- a/src/awardsreport/logic/topline.py
+++ b/src/awardsreport/logic/topline.py
@@ -1,7 +1,7 @@
-from awardsreport.database import Session
 from awardsreport.models import ProcurementTransactions, AssistanceTransactions
 from awardsreport.helpers.seed_helpers import YEAR, MONTH
-from sqlalchemy import select, func, desc, extract
+from awardsreport.schemas.topline import MonthTotalsAwardType2Cat
+from sqlalchemy import select, func, extract
 from sqlalchemy.orm import Session
 
 
@@ -50,22 +50,24 @@ def get_award_type_month_total(
     return results
 
 
-# todo: create a schema for returned object
-def get_month_totals_2cat(year: int = YEAR, month: int = MONTH):
+def get_month_totals_award_type_2cat(
+    session: Session, year: int = YEAR, month: int = MONTH
+) -> MonthTotalsAwardType2Cat:
     """Get total spending in specified year and month.
 
     args:
+        session sqlalchemy.orm.Session
         year int year of spending to sum
         month int month on spending to sum
 
-    returns dict
+    returns awardsreport.schemas.topline.MonthTotalAwardType2Cat
 
 
     """
     month_totals = {
-        "assistance": get_award_type_month_total("assistance", year, month)
-        + get_award_type_month_total("loan", year, month),
-        "procurement": get_award_type_month_total("procurement", year, month),
+        "assistance": get_award_type_month_total(session, "assistance", year, month)
+        + get_award_type_month_total(session, "loan", year, month),
+        "procurement": get_award_type_month_total(session, "procurement", year, month),
     }
     return {
         "year": year,

--- a/src/awardsreport/routers/topline.py
+++ b/src/awardsreport/routers/topline.py
@@ -19,7 +19,7 @@ async def award_type_month_total(
     return result
 
 
-@router.get("/month_totals_2cat_award_type", response_model=MonthTotalsAwardType2Cat)
+@router.get("/month_totals_award_type_2cat", response_model=MonthTotalsAwardType2Cat)
 async def month_totals_award_type_2cat(
     db: Session = Depends(get_db), year: int = Query(...), month: int = Query(...)
 ):

--- a/src/awardsreport/routers/topline.py
+++ b/src/awardsreport/routers/topline.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter, Depends, Query
-from typing import List
 
 from awardsreport.logic import topline
-from awardsreport.schemas.topline import AgencyObligations
+from awardsreport.schemas.topline import MonthTotalsAwardType2Cat
 from awardsreport.database import get_db
 from sqlalchemy.orm import Session
 
@@ -17,4 +16,12 @@ async def award_type_month_total(
     month: int = Query(...),
 ):
     result = topline.get_award_type_month_total(db, award_type, year, month)
+    return result
+
+
+@router.get("/month_totals_2cat_award_type", response_model=MonthTotalsAwardType2Cat)
+async def month_totals_award_type_2cat(
+    db: Session = Depends(get_db), year: int = Query(...), month: int = Query(...)
+):
+    result = topline.get_month_totals_award_type_2cat(db, year, month)
     return result

--- a/src/awardsreport/schemas/topline.py
+++ b/src/awardsreport/schemas/topline.py
@@ -14,3 +14,10 @@ class AwardTypeTotals2cat(BaseModel):
 class MonthTotals2cat(BaseModel):
     year: str
     month: str
+
+
+class MonthTotalsAwardType2Cat(BaseModel):
+    year: str
+    month: str
+    total: float
+    award_type_totals: AwardTypeTotals2cat

--- a/src/tests/test_topline.py
+++ b/src/tests/test_topline.py
@@ -2,26 +2,49 @@ import pytest
 from awardsreport.logic import topline
 from sqlalchemy.orm import Session
 
-from tests.factories import AssistanceTransactionsFactory
+from tests.factories import (
+    AssistanceTransactionsFactory,
+    ProcurementTransactionsFactory,
+)
 
 
 def test_get_award_type_month_total(db_session: Session):
     db_session.add_all(
         [
             AssistanceTransactionsFactory(
-                federal_action_obligation=1, action_date="2023-05-01"
+                federal_action_obligation=2,
+                action_date="2023-05-01",
+                assistance_type_code="01",
             ),
             AssistanceTransactionsFactory(
-                federal_action_obligation=1, action_date="2023-05-31"
+                federal_action_obligation=-1,
+                action_date="2023-05-01",
+                assistance_type_code="01",
             ),
             AssistanceTransactionsFactory(
-                federal_action_obligation=-1, action_date="2023-05-01"
+                federal_action_obligation=1,
+                action_date="2023-06-01",
+                assistance_type_code="01",
             ),
             AssistanceTransactionsFactory(
-                federal_action_obligation=1, action_date="2023-06-01"
+                federal_action_obligation=1,
+                action_date="2022-05-01",
+                assistance_type_code="01",
             ),
             AssistanceTransactionsFactory(
-                federal_action_obligation=1, action_date="2022-05-01"
+                federal_action_obligation=2,
+                original_loan_subsidy_cost=3,
+                action_date="2023-05-01",
+                assistance_type_code="07",
+            ),
+            ProcurementTransactionsFactory(
+                federal_action_obligation=100, action_date="2023-05-01"
+            ),
+            ProcurementTransactionsFactory(
+                federal_action_obligation=-50, action_date="2023-05-01"
+            ),
+            ProcurementTransactionsFactory(
+                federal_action_obligation=100, action_date="2023-06-01"
             ),
         ]
     )
@@ -29,4 +52,12 @@ def test_get_award_type_month_total(db_session: Session):
 
     result = topline.get_award_type_month_total(db_session, "assistance", 2023, 5)
     expected_result = 1
+    assert result == expected_result
+
+    result = topline.get_award_type_month_total(db_session, "loan", 2023, 5)
+    expected_result = 3
+    assert result == expected_result
+
+    result = topline.get_award_type_month_total(db_session, "procurement", 2023, 5)
+    expected_result = 50
     assert result == expected_result

--- a/src/tests/test_topline.py
+++ b/src/tests/test_topline.py
@@ -8,46 +8,49 @@ from tests.factories import (
 )
 
 
-def test_get_award_type_month_total(db_session: Session):
-    db_session.add_all(
-        [
-            AssistanceTransactionsFactory(
-                federal_action_obligation=2,
-                action_date="2023-05-01",
-                assistance_type_code="01",
-            ),
-            AssistanceTransactionsFactory(
-                federal_action_obligation=-1,
-                action_date="2023-05-01",
-                assistance_type_code="01",
-            ),
-            AssistanceTransactionsFactory(
-                federal_action_obligation=1,
-                action_date="2023-06-01",
-                assistance_type_code="01",
-            ),
-            AssistanceTransactionsFactory(
-                federal_action_obligation=1,
-                action_date="2022-05-01",
-                assistance_type_code="01",
-            ),
-            AssistanceTransactionsFactory(
-                federal_action_obligation=2,
-                original_loan_subsidy_cost=3,
-                action_date="2023-05-01",
-                assistance_type_code="07",
-            ),
-            ProcurementTransactionsFactory(
-                federal_action_obligation=100, action_date="2023-05-01"
-            ),
-            ProcurementTransactionsFactory(
-                federal_action_obligation=-50, action_date="2023-05-01"
-            ),
-            ProcurementTransactionsFactory(
-                federal_action_obligation=100, action_date="2023-06-01"
-            ),
-        ]
-    )
+@pytest.fixture
+def test_data():
+    return [
+        AssistanceTransactionsFactory(
+            federal_action_obligation=2,
+            action_date="2023-05-01",
+            assistance_type_code="01",
+        ),
+        AssistanceTransactionsFactory(
+            federal_action_obligation=-1,
+            action_date="2023-05-01",
+            assistance_type_code="01",
+        ),
+        AssistanceTransactionsFactory(
+            federal_action_obligation=1,
+            action_date="2023-06-01",
+            assistance_type_code="01",
+        ),
+        AssistanceTransactionsFactory(
+            federal_action_obligation=1,
+            action_date="2022-05-01",
+            assistance_type_code="01",
+        ),
+        AssistanceTransactionsFactory(
+            federal_action_obligation=2,
+            original_loan_subsidy_cost=3,
+            action_date="2023-05-01",
+            assistance_type_code="07",
+        ),
+        ProcurementTransactionsFactory(
+            federal_action_obligation=100, action_date="2023-05-01"
+        ),
+        ProcurementTransactionsFactory(
+            federal_action_obligation=-50, action_date="2023-05-01"
+        ),
+        ProcurementTransactionsFactory(
+            federal_action_obligation=100, action_date="2023-06-01"
+        ),
+    ]
+
+
+def test_get_award_type_month_total(db_session: Session, test_data: list):
+    db_session.add_all(test_data)
     db_session.commit()
 
     result = topline.get_award_type_month_total(db_session, "assistance", 2023, 5)
@@ -60,4 +63,17 @@ def test_get_award_type_month_total(db_session: Session):
 
     result = topline.get_award_type_month_total(db_session, "procurement", 2023, 5)
     expected_result = 50
+    assert result == expected_result
+
+
+def test_get_month_totals_award_type_2cat(db_session: Session, test_data: list):
+    db_session.add_all(test_data)
+    db_session.commit()
+    result = topline.get_month_totals_award_type_2cat(db_session, 2023, 5)
+    expected_result = {
+        "year": 2023,
+        "month": 5,
+        "total": 54,
+        "award_type_totals": {"assistance": 4, "procurement": 50},
+    }
     assert result == expected_result


### PR DESCRIPTION
src/awardsreport/logic/topline.py
- filter by assistance type code in non-loan transactions
- create get_month_totals_award_type_2cat to replace get_month_totals_2cat
- remove unused get_agency_obligations

src/awardsreport/routers/topline.py
- implement topline/month_totals_award_type_2cat

src/awardsreport/schemas/topline.py
- create pydantic model MonthTotalsAwardType2Cat

src/tests/test_topline.py
- create loan, non-loan, and procurement test data
- test get_month_totals_award_type_2cat