### PR TITLE
Add selective seed column ingestion and fiscal-quarter dbt spending models

### DIFF
--- a/dbt/awards_dbt/macros/fiscal_calendar.sql
+++ b/dbt/awards_dbt/macros/fiscal_calendar.sql
@@ -14,6 +14,8 @@
         when extract(month from {{ date_expr }}) in (10, 11, 12) then 1
         when extract(month from {{ date_expr }}) in (1, 2, 3) then 2
         when extract(month from {{ date_expr }}) in (4, 5, 6) then 3
+        when extract(month from {{ date_expr }}) in (7, 8, 9) then 4
+
     end
 )
 {%- endmacro %}

--- a/dbt/awards_dbt/models/marts/mart_top10_spend_by_dim_fq.sql
+++ b/dbt/awards_dbt/models/marts/mart_top10_spend_by_dim_fq.sql
@@ -1,3 +1,5 @@
+{{ config(materialized='table') }}
+
 with ranked as (
 
     select

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,12 @@ build-backend = "poetry.core.masonry.api"
 pythonpath = [
   "src/awardsreport"
 ]
+norecursedirs = [
+  "dbt",
+  "dbt_packages",
+  "target",
+  ".git",
+  ".venv",
+  "venv",
+  "__pycache__"
+]

--- a/src/awardsreport/setup/seed.py
+++ b/src/awardsreport/setup/seed.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import requests
+import csv
 from time import sleep
 from zipfile import ZipFile
 from io import BytesIO
@@ -47,7 +48,11 @@ def _payload_for_log(payload_dict: dict[str, Any]) -> dict[str, Any]:
     return d
 
 
-def awards_usas_to_sql(start_date: str, end_date: Optional[str] = None):
+def awards_usas_to_sql(
+    start_date: str,
+    end_date: Optional[str] = None,
+    selected_cols: Optional[list[str]] = None,
+):
     def get_status(status_url):
         logger.info(f"GET status: {status_url}")
         resp = requests.get(status_url, headers=USER_AGENT, timeout=60)
@@ -56,7 +61,7 @@ def awards_usas_to_sql(start_date: str, end_date: Optional[str] = None):
         logger.info(f"status response: {j}")
         return j["status"]
 
-    payloads = get_awards_payloads(start_date, end_date)
+    payloads = get_awards_payloads(start_date, end_date, columns=selected_cols)
     logger.info("Starting seed run")
     logger.info(f"payload count: {len(payloads)}")
     logger.info(
@@ -128,10 +133,16 @@ def awards_usas_to_sql(start_date: str, end_date: Optional[str] = None):
             logger.info(f"csv files: {files}")
 
             for csv_name in files:
-                copy_cmd = generate_copy_from_sql(csv_name)
-                logger.info(f"copy_cmd for {csv_name}: {copy_cmd}")
+                with open(
+                    f"{raw_data}/{csv_name}", "r", encoding="utf-8", newline=""
+                ) as f:
+                    reader = csv.reader(f)
+                    header = next(reader)
+                    f.seek(0)
 
-                with open(f"{raw_data}/{csv_name}", "r") as f:
+                    copy_cmd = generate_copy_from_sql(csv_name, columns=header)
+                    logger.info(f"copy_cmd for {csv_name}: {copy_cmd}")
+
                     cursor.copy_expert(copy_cmd, f)
                     conn.commit()
                     logger.info(f"committed {csv_name}")
@@ -155,5 +166,14 @@ if __name__ == "__main__":
         help="YYYY-MM-DD Filter transactions by action_date <= (default = today).",
         required=False,
     )
+    parser.add_argument(
+        "--cols",
+        type=str,
+        required=False,
+        help="Comma-separated list of USAspending columns to request (optional). Example: action_date,awarding_agency_name,cfda_number",
+    )
     args = parser.parse_args()
-    awards_usas_to_sql(args.s, args.e)
+    selected_cols = None
+    if args.cols:
+        selected_cols = [c.strip() for c in args.cols.split(",") if c.strip()]
+    awards_usas_to_sql(args.s, args.e, selected_cols)

--- a/src/awardsreport/setup/seed_helpers.py
+++ b/src/awardsreport/setup/seed_helpers.py
@@ -115,7 +115,9 @@ def get_date_ranges(
 
 
 def get_awards_payloads(
-    start_date: str, end_date: Optional[str] = None
+    start_date: str,
+    end_date: Optional[str] = None,
+    columns: Optional[list[str]] = None,
 ) -> list[seed_helpers_schemas.AwardsPayload]:
     """Generate payloads for USAs awards download from start_date to end_date.
 
@@ -128,14 +130,22 @@ def get_awards_payloads(
     returns list[seed_helpers_schemas.AwardsPayload]for api/v2/bulk_downloads/awards/
     """
 
-    columns = sorted(
+    default_columns = sorted(
         set(get_raw_columns(AssistanceTransactions))
         | set(get_raw_columns(ProcurementTransactions))
     )
 
+    if columns is None:
+        requested_columns = default_columns
+    else:
+        unknown = [c for c in columns if c not in default_columns]
+        if unknown:
+            raise ValueError(f"Unknown columns requested: {unknown}")
+        requested_columns = columns
+
     payloads = [
         seed_helpers_schemas.AwardsPayload(
-            columns=columns,
+            columns=requested_columns,
             filters=seed_helpers_schemas.AwardsPayloadFilters(
                 prime_award_types=PRIME_AWARD_TYPES,
                 date_type="action_date",
@@ -148,12 +158,13 @@ def get_awards_payloads(
         )
         for start_date, end_date in get_date_ranges(start_date, end_date)
     ]
-
     return payloads
 
 
 def generate_copy_from_sql(
-    fname: str, test_cols: Dict[str, List[str]] | None = None
+    fname: str,
+    test_cols: Dict[str, List[str]] | None = None,
+    columns: list[str] | None = None,
 ) -> str:
     """Generate sql COPY FROM command to insert to psql.
 
@@ -164,34 +175,42 @@ def generate_copy_from_sql(
         fname str file name to insert
         test_cols TestColsType COPY columns to simplify testing. Users should
         not need to interact with this parameter.
+        columns optional explicit column list in CSV order
 
-    return str valid postgresql COPY FROM statement to insert data from fname to appropriate table.
+    return str valid postgresql COPY FROM statement to insert data from fname
+    to appropriate table.
 
     raises
         ValueError if provided test_col keys are not exactly 'asst_cols' and 'proc_cols'.
-        ValueError if fname does not inclue 'Assistance' or 'Contract'
+        ValueError if fname does not include 'Assistance' or 'Contract'
     """
-    if test_cols:
-        valid_keys = {"asst_cols", "proc_cols"}
-        test_col_keys = test_cols.keys()
-        if set(test_col_keys) != (valid_keys):
-            raise ValueError(
-                f"invalid test_cols keys: {test_col_keys}. test_col keys must be 'asst_cols' and 'proc_cols'"
-            )
-        asst_cols = test_cols["asst_cols"]
-        proc_cols = test_cols["proc_cols"]
-    else:
-        asst_cols = get_raw_columns(AssistanceTransactions)
-        proc_cols = get_raw_columns(ProcurementTransactions)
-
     if "Assistance" in fname:
-        cols = ", ".join(asst_cols)
         table_name = "assistance_transactions"
+        default_cols = get_raw_columns(AssistanceTransactions)
     elif "Contract" in fname:
-        cols = ", ".join(proc_cols)
         table_name = "procurement_transactions"
+        default_cols = get_raw_columns(ProcurementTransactions)
     else:
         raise ValueError(
             f"invalid fname: {fname}. fname must include substring 'Assistance' or 'Contract'"
         )
+
+    if test_cols:
+        valid_keys = {"asst_cols", "proc_cols"}
+        test_col_keys = test_cols.keys()
+        if set(test_col_keys) != valid_keys:
+            raise ValueError(
+                f"invalid test_cols keys: {test_col_keys}. test_col keys must be 'asst_cols' and 'proc_cols'"
+            )
+        cols_list = (
+            test_cols["asst_cols"]
+            if table_name == "assistance_transactions"
+            else test_cols["proc_cols"]
+        )
+    elif columns is not None:
+        cols_list = columns
+    else:
+        cols_list = default_cols
+
+    cols = ", ".join(cols_list)
     return f"COPY {table_name}({cols}) FROM STDIN WITH (FORMAT CSV, HEADER)"

--- a/src/tests/setup/test_seed_helpers.py
+++ b/src/tests/setup/test_seed_helpers.py
@@ -222,12 +222,14 @@ def test_get_date_ranges():
 
 
 def test_get_awards_payload():
+    expected_columns = sorted(
+        set(seed_helpers.get_raw_columns(AssistanceTransactions))
+        | set(seed_helpers.get_raw_columns(ProcurementTransactions))
+    )
+
     expected_results = [
         {
-            "columns": list(
-                set(seed_helpers.get_raw_columns(AssistanceTransactions))
-                | set(seed_helpers.get_raw_columns(ProcurementTransactions))
-            ),
+            "columns": expected_columns,
             "file_format": "csv",
             "filters": {
                 "agencies": [{"name": "All", "tier": "toptier", "type": "awarding"}],
@@ -237,10 +239,7 @@ def test_get_awards_payload():
             },
         },
         {
-            "columns": list(
-                set(seed_helpers.get_raw_columns(AssistanceTransactions))
-                | set(seed_helpers.get_raw_columns(ProcurementTransactions))
-            ),
+            "columns": expected_columns,
             "file_format": "csv",
             "filters": {
                 "agencies": [{"name": "All", "tier": "toptier", "type": "awarding"}],
@@ -250,6 +249,7 @@ def test_get_awards_payload():
             },
         },
     ]
+
     results = seed_helpers.get_awards_payloads(
         start_date="2022-10-01", end_date="2023-10-31"
     )
@@ -273,3 +273,30 @@ def test_generate_copy_from_sql():
     # test test_cols keys exception
     with pytest.raises(ValueError):
         seed_helpers.generate_copy_from_sql("Assistance", {"invalid_key": ["foo"]})
+
+
+def test_generate_copy_from_sql_explicit_columns():
+    result = seed_helpers.generate_copy_from_sql(
+        "Assistance_1.csv",
+        columns=["action_date", "awarding_agency_name"],
+    )
+    assert (
+        result
+        == "COPY assistance_transactions(action_date, awarding_agency_name) FROM STDIN WITH (FORMAT CSV, HEADER)"
+    )
+
+
+def test_get_awards_payload_preserves_requested_column_order():
+    requested_columns = [
+        "recipient_name",
+        "action_date",
+        "awarding_agency_name",
+    ]
+
+    results = seed_helpers.get_awards_payloads(
+        start_date="2023-10-01",
+        end_date="2023-10-31",
+        columns=requested_columns,
+    )
+
+    assert results[0].columns == requested_columns


### PR DESCRIPTION
## Summary

This PR adds selective column ingestion to the USAspending seed pipeline and introduces dbt models for fiscal-quarter spending analysis.

## What changed

### Seed pipeline
- Add `--cols` option to `seed.py` so bulk downloads can request a selected subset of columns
- Preserve requested column order in the USAspending payload
- Update COPY logic to derive columns from the CSV header so COPY matches the downloaded file
- Keep backward compatibility in `generate_copy_from_sql`
- Add tests covering ordered requested columns

### dbt
- Add / update fiscal calendar macros
- Add `int_spend_by_dim_fq` intermediate model for spending aggregated by:
  - fiscal year
  - fiscal quarter
  - source_table
  - dimension type / value
- Add `mart_top10_spend_by_dim_fq` mart for top-10 spending by dimension and fiscal quarter
- Add / update dbt tests for these models

### Test / config updates
- Update pytest configuration / tests as needed for the new seed behavior
- Update seed helper tests for deterministic default column ordering

## Why

The main goal of this PR is to reduce local disk usage during USAspending ingestion while supporting wider historical ranges for analysis.

Selective ingestion makes it practical to:
- seed only the columns needed for current dbt models
- work with larger date ranges locally
- avoid unnecessary storage costs from loading the full raw schema every time

The dbt additions provide a reusable base for fiscal-quarter analysis and top-10 spending exploration.

## Validation

### Seed pipeline
- Ran a smoke test with a narrow selected column set using `--cols`
- Confirmed the seed request only asked for the selected columns
- Confirmed COPY used the CSV header ordering
- Confirmed tests pass for seed helper changes

### dbt
- Ran:
  - `dbt run --select int_spend_by_dim_fq mart_top10_spend_by_dim_fq --threads 1`
  - `dbt test --select int_spend_by_dim_fq mart_top10_spend_by_dim_fq --threads 1`
- All selected dbt tests passed on real seeded data

## Notes
- `int_spend_by_dim_fq` is materialized as a view
- `mart_top10_spend_by_dim_fq` is materialized as a table
- No API behavior changes are included in this PR